### PR TITLE
Enable wasmJS support for ReleaseFetcher

### DIFF
--- a/platformtools/releasefetcher/build.gradle.kts
+++ b/platformtools/releasefetcher/build.gradle.kts
@@ -18,8 +18,7 @@ kotlin {
 
     androidTarget { publishLibraryVariants("release") }
     jvm()
-
-//    wasmJs { browser() }
+    wasmJs { browser() }
 
     sourceSets {
         commonMain.dependencies {
@@ -40,13 +39,22 @@ kotlin {
             implementation(kotlin("test"))
         }
 
-        jvmMain.dependencies {
-            implementation(libs.slf4j.simple)
-
+        val androidJvmMain by creating {
+            dependsOn(commonMain.get())
         }
 
-        androidMain.dependencies {
+        jvmMain {
+            dependsOn(androidJvmMain)
+            dependencies {
+                implementation(libs.slf4j.simple)
+            }
+        }
+
+        androidMain {
+            dependsOn(androidJvmMain)
+            dependencies {
                 implementation(libs.androidcontextprovider)
+            }
         }
 
         wasmJsMain.dependencies {

--- a/platformtools/releasefetcher/src/androidJvmMain/kotlin/io/github/kdroidfilter/platformtools/releasefetcher/downloader/Downloader.android.kt
+++ b/platformtools/releasefetcher/src/androidJvmMain/kotlin/io/github/kdroidfilter/platformtools/releasefetcher/downloader/Downloader.android.kt
@@ -1,0 +1,99 @@
+package io.github.kdroidfilter.platformtools.releasefetcher.downloader
+
+import co.touchlab.kermit.Logger
+import co.touchlab.kermit.Logger.Companion.setMinSeverity
+import co.touchlab.kermit.Severity
+import io.github.kdroidfilter.platformtools.getCacheDir
+import io.github.kdroidfilter.platformtools.releasefetcher.config.client
+import io.ktor.client.call.*
+import io.ktor.client.plugins.*
+import io.ktor.client.request.*
+import io.ktor.http.*
+import io.ktor.utils.io.*
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import io.github.kdroidfilter.platformtools.releasefetcher.downloader.PlatformFile
+import java.io.File
+
+private val logger = Logger.withTag("Downloader").apply { setMinSeverity(Severity.Warn) }
+
+
+/**
+ * Downloader is responsible for handling file downloads from a given URL.
+ * This class provides functionality to asynchronously download files, report
+ * download progress, and handle errors that may occur during the download process.
+ */
+actual class Downloader {
+
+    /**
+     * Downloads an application file from the provided URL and tracks the download progress.
+     *
+     * @param downloadUrl The URL from which the application will be downloaded.
+     * @param onProgress A callback function reporting download progress percentage and the downloaded file (if available).
+     *                     The percentage is a `Double` ranging from 0.0 to 100.0, or -1.0 in case of errors.
+     *                     The `file` parameter is the local file being downloaded, or `null` during download progress updates.
+     * @return A `Boolean` indicating whether the download was successful.
+     *         Returns `true` if the download completes successfully, otherwise `false`.
+     */
+    actual suspend fun downloadApp(
+        downloadUrl: String,
+        onProgress: (percentage: Double, file: PlatformFile?) -> Unit
+    ): Boolean {
+        val bufferSize = ReleaseFetcherConfig.downloaderBufferSize
+        logger.d { "Starting download from URL: $downloadUrl" }
+
+        val fileName = downloadUrl.substringAfterLast('/').substringBefore('?')
+        val cacheDir = getCacheDir()
+        val destinationFile = File(cacheDir, fileName)
+
+        onProgress(0.0, null)
+        logger.d { "Download initialized: 0%" }
+
+        return try {
+            val response = client.get(downloadUrl) {
+                onDownload { bytesSentTotal, contentLength ->
+                    val progress = if (contentLength != null && contentLength > 0) {
+                        (bytesSentTotal * 100.0 / contentLength)
+                    } else 0.0
+                    logger.d { "Progress: $bytesSentTotal / $contentLength bytes" }
+                    onProgress(progress, null)
+                }
+            }
+
+            if (response.status.isSuccess()) {
+                val channel: ByteReadChannel = response.body()
+                val contentLength = response.contentLength() ?: -1L
+                logger.d { "Content length: $contentLength bytes" }
+
+                withContext(Dispatchers.IO) {
+                    destinationFile.outputStream().buffered(bufferSize).use { output ->
+                        val buffer = ByteArray(bufferSize)
+                        while (!channel.isClosedForRead) {
+                            val bytesRead = channel.readAvailable(buffer)
+                            if (bytesRead == -1) break
+                            output.write(buffer, 0, bytesRead)
+                        }
+                    }
+                }
+
+                if (destinationFile.exists()) {
+                    logger.d { "Download completed. Size: ${destinationFile.length()} bytes" }
+                    onProgress(100.0, destinationFile)
+                    true
+                } else {
+                    logger.e { "Error: File not created" }
+                    onProgress(-1.0, null)  // Keep -1.0 for errors
+                    false
+                }
+            } else {
+                logger.e { "Download failed: ${response.status}" }
+                onProgress(-1.0, null)  // Keep -1.0 for errors
+                false
+            }
+        } catch (e: Exception) {
+            logger.e(e) { "Download error: ${e.message}" }
+            onProgress(-1.0, null)  // Keep -1.0 for errors
+            false
+        }
+    }
+}

--- a/platformtools/releasefetcher/src/androidJvmMain/kotlin/io/github/kdroidfilter/platformtools/releasefetcher/downloader/Downloader.android.kt
+++ b/platformtools/releasefetcher/src/androidJvmMain/kotlin/io/github/kdroidfilter/platformtools/releasefetcher/downloader/Downloader.android.kt
@@ -35,7 +35,7 @@ actual class Downloader {
      * @return A `Boolean` indicating whether the download was successful.
      *         Returns `true` if the download completes successfully, otherwise `false`.
      */
-    actual suspend fun downloadApp(
+    actual suspend fun download(
         downloadUrl: String,
         onProgress: (percentage: Double, file: PlatformFile?) -> Unit
     ): Boolean {

--- a/platformtools/releasefetcher/src/androidJvmMain/kotlin/io/github/kdroidfilter/platformtools/releasefetcher/downloader/PlatformFile.androidJvm.kt
+++ b/platformtools/releasefetcher/src/androidJvmMain/kotlin/io/github/kdroidfilter/platformtools/releasefetcher/downloader/PlatformFile.androidJvm.kt
@@ -1,0 +1,3 @@
+package io.github.kdroidfilter.platformtools.releasefetcher.downloader
+
+actual typealias PlatformFile = java.io.File

--- a/platformtools/releasefetcher/src/androidJvmMain/kotlin/io/github/kdroidfilter/platformtools/releasefetcher/github/VersionUtils.androidJvm.kt
+++ b/platformtools/releasefetcher/src/androidJvmMain/kotlin/io/github/kdroidfilter/platformtools/releasefetcher/github/VersionUtils.androidJvm.kt
@@ -1,0 +1,5 @@
+package io.github.kdroidfilter.platformtools.releasefetcher.github
+
+import io.github.kdroidfilter.platformtools.getAppVersion
+
+actual fun getCurrentAppVersion(): String = getAppVersion()

--- a/platformtools/releasefetcher/src/commonMain/kotlin/io/github/kdroidfilter/platformtools/releasefetcher/downloader/Downloader.kt
+++ b/platformtools/releasefetcher/src/commonMain/kotlin/io/github/kdroidfilter/platformtools/releasefetcher/downloader/Downloader.kt
@@ -1,98 +1,14 @@
 package io.github.kdroidfilter.platformtools.releasefetcher.downloader
 
-import co.touchlab.kermit.Logger
-import co.touchlab.kermit.Logger.Companion.setMinSeverity
-import co.touchlab.kermit.Severity
-import io.github.kdroidfilter.platformtools.getCacheDir
-import io.github.kdroidfilter.platformtools.releasefetcher.config.client
-import io.ktor.client.call.*
-import io.ktor.client.plugins.*
-import io.ktor.client.request.*
-import io.ktor.http.*
-import io.ktor.utils.io.*
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
-import java.io.File
+/** Represents a file downloaded by [Downloader]. */
+expect class PlatformFile
 
-private val logger = Logger.withTag("Downloader").apply { setMinSeverity(Severity.Warn) }
-
-
-/**
- * Downloader is responsible for handling file downloads from a given URL.
- * This class provides functionality to asynchronously download files, report
- * download progress, and handle errors that may occur during the download process.
- */
-class Downloader {
-
+/** Platform-agnostic downloader interface. */
+expect class Downloader() {
     /**
-     * Downloads an application file from the provided URL and tracks the download progress.
-     *
-     * @param downloadUrl The URL from which the application will be downloaded.
-     * @param onProgress A callback function reporting download progress percentage and the downloaded file (if available).
-     *                     The percentage is a `Double` ranging from 0.0 to 100.0, or -1.0 in case of errors.
-     *                     The `file` parameter is the local file being downloaded, or `null` during download progress updates.
-     * @return A `Boolean` indicating whether the download was successful.
-     *         Returns `true` if the download completes successfully, otherwise `false`.
+     * Downloads a file from [downloadUrl].
+     * [onProgress] is called with percentage progress and the resulting file when complete.
+     * Returns `true` on success.
      */
-    suspend fun downloadApp(
-        downloadUrl: String,
-        onProgress: (percentage: Double, file: File?) -> Unit
-    ): Boolean {
-        val bufferSize = ReleaseFetcherConfig.downloaderBufferSize
-        logger.d { "Starting download from URL: $downloadUrl" }
-
-        val fileName = downloadUrl.substringAfterLast('/').substringBefore('?')
-        val cacheDir = getCacheDir()
-        val destinationFile = File(cacheDir, fileName)
-
-        onProgress(0.0, null)
-        logger.d { "Download initialized: 0%" }
-
-        return try {
-            val response = client.get(downloadUrl) {
-                onDownload { bytesSentTotal, contentLength ->
-                    val progress = if (contentLength != null && contentLength > 0) {
-                        (bytesSentTotal * 100.0 / contentLength)
-                    } else 0.0
-                    logger.d { "Progress: $bytesSentTotal / $contentLength bytes" }
-                    onProgress(progress, null)
-                }
-            }
-
-            if (response.status.isSuccess()) {
-                val channel: ByteReadChannel = response.body()
-                val contentLength = response.contentLength() ?: -1L
-                logger.d { "Content length: $contentLength bytes" }
-
-                withContext(Dispatchers.IO) {
-                    destinationFile.outputStream().buffered(bufferSize).use { output ->
-                        val buffer = ByteArray(bufferSize)
-                        while (!channel.isClosedForRead) {
-                            val bytesRead = channel.readAvailable(buffer)
-                            if (bytesRead == -1) break
-                            output.write(buffer, 0, bytesRead)
-                        }
-                    }
-                }
-
-                if (destinationFile.exists()) {
-                    logger.d { "Download completed. Size: ${destinationFile.length()} bytes" }
-                    onProgress(100.0, destinationFile)
-                    true
-                } else {
-                    logger.e { "Error: File not created" }
-                    onProgress(-1.0, null)  // Keep -1.0 for errors
-                    false
-                }
-            } else {
-                logger.e { "Download failed: ${response.status}" }
-                onProgress(-1.0, null)  // Keep -1.0 for errors
-                false
-            }
-        } catch (e: Exception) {
-            logger.e(e) { "Download error: ${e.message}" }
-            onProgress(-1.0, null)  // Keep -1.0 for errors
-            false
-        }
-    }
+    suspend fun downloadApp(downloadUrl: String, onProgress: (percentage: Double, file: PlatformFile?) -> Unit): Boolean
 }

--- a/platformtools/releasefetcher/src/commonMain/kotlin/io/github/kdroidfilter/platformtools/releasefetcher/downloader/Downloader.kt
+++ b/platformtools/releasefetcher/src/commonMain/kotlin/io/github/kdroidfilter/platformtools/releasefetcher/downloader/Downloader.kt
@@ -10,5 +10,5 @@ expect class Downloader() {
      * [onProgress] is called with percentage progress and the resulting file when complete.
      * Returns `true` on success.
      */
-    suspend fun downloadApp(downloadUrl: String, onProgress: (percentage: Double, file: PlatformFile?) -> Unit): Boolean
+    suspend fun download(downloadUrl: String, onProgress: (percentage: Double, file: PlatformFile?) -> Unit): Boolean
 }

--- a/platformtools/releasefetcher/src/commonMain/kotlin/io/github/kdroidfilter/platformtools/releasefetcher/github/GitHubReleaseFetcher.kt
+++ b/platformtools/releasefetcher/src/commonMain/kotlin/io/github/kdroidfilter/platformtools/releasefetcher/github/GitHubReleaseFetcher.kt
@@ -1,17 +1,15 @@
 package io.github.kdroidfilter.platformtools.releasefetcher.github
 
 import io.github.kdroidfilter.platformtools.OperatingSystem
-import io.github.kdroidfilter.platformtools.getAppVersion
 import io.github.kdroidfilter.platformtools.getOperatingSystem
 import io.github.kdroidfilter.platformtools.releasefetcher.config.client
 import io.github.kdroidfilter.platformtools.releasefetcher.github.model.Release
+import io.github.kdroidfilter.platformtools.releasefetcher.github.getCurrentAppVersion
 import io.github.z4kn4fein.semver.toVersion
 import io.ktor.client.call.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 
 class GitHubReleaseFetcher(
@@ -24,8 +22,8 @@ class GitHubReleaseFetcher(
     /**
      * Fetches the latest release from the GitHub API using Ktor.
      */
-    suspend fun getLatestRelease(): Release? = withContext(Dispatchers.IO) {
-        try {
+    suspend fun getLatestRelease(): Release? {
+        return try {
             val response: HttpResponse = client.get("https://api.github.com/repos/$owner/$repo/releases/latest")
 
             if (response.status == HttpStatusCode.OK) {
@@ -50,7 +48,7 @@ class GitHubReleaseFetcher(
     ) {
         val latestRelease = getLatestRelease()
         if (latestRelease != null) {
-            val currentVersion = getAppVersion().toVersion(strict = false)
+            val currentVersion = getCurrentAppVersion().toVersion(strict = false)
             val latestVersion = latestRelease.tag_name.toVersion(strict = false)
 
             if (latestVersion > currentVersion) {

--- a/platformtools/releasefetcher/src/commonMain/kotlin/io/github/kdroidfilter/platformtools/releasefetcher/github/VersionUtils.kt
+++ b/platformtools/releasefetcher/src/commonMain/kotlin/io/github/kdroidfilter/platformtools/releasefetcher/github/VersionUtils.kt
@@ -1,0 +1,4 @@
+package io.github.kdroidfilter.platformtools.releasefetcher.github
+
+/** Returns the current application version. */
+expect fun getCurrentAppVersion(): String

--- a/platformtools/releasefetcher/src/wasmJsMain/kotlin/io/github/kdroidfilter/platformtools/releasefetcher/downloader/Downloader.wasmJs.kt
+++ b/platformtools/releasefetcher/src/wasmJsMain/kotlin/io/github/kdroidfilter/platformtools/releasefetcher/downloader/Downloader.wasmJs.kt
@@ -1,0 +1,31 @@
+package io.github.kdroidfilter.platformtools.releasefetcher.downloader
+
+import io.github.kdroidfilter.platformtools.releasefetcher.config.client
+import io.ktor.client.call.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+
+actual class Downloader {
+    actual suspend fun downloadApp(
+        downloadUrl: String,
+        onProgress: (percentage: Double, file: PlatformFile?) -> Unit
+    ): Boolean {
+        return try {
+            onProgress(0.0, null)
+            val response: HttpResponse = client.get(downloadUrl)
+            if (response.status.isSuccess()) {
+                val bytes: ByteArray = response.body()
+                val name = downloadUrl.substringAfterLast('/')
+                onProgress(100.0, PlatformFile(name, bytes))
+                true
+            } else {
+                onProgress(-1.0, null)
+                false
+            }
+        } catch (e: Exception) {
+            onProgress(-1.0, null)
+            false
+        }
+    }
+}

--- a/platformtools/releasefetcher/src/wasmJsMain/kotlin/io/github/kdroidfilter/platformtools/releasefetcher/downloader/Downloader.wasmJs.kt
+++ b/platformtools/releasefetcher/src/wasmJsMain/kotlin/io/github/kdroidfilter/platformtools/releasefetcher/downloader/Downloader.wasmJs.kt
@@ -7,7 +7,7 @@ import io.ktor.client.statement.*
 import io.ktor.http.*
 
 actual class Downloader {
-    actual suspend fun downloadApp(
+    actual suspend fun download(
         downloadUrl: String,
         onProgress: (percentage: Double, file: PlatformFile?) -> Unit
     ): Boolean {

--- a/platformtools/releasefetcher/src/wasmJsMain/kotlin/io/github/kdroidfilter/platformtools/releasefetcher/downloader/PlatformFile.wasmJs.kt
+++ b/platformtools/releasefetcher/src/wasmJsMain/kotlin/io/github/kdroidfilter/platformtools/releasefetcher/downloader/PlatformFile.wasmJs.kt
@@ -1,0 +1,3 @@
+package io.github.kdroidfilter.platformtools.releasefetcher.downloader
+
+actual class PlatformFile(val name: String, val bytes: ByteArray)

--- a/platformtools/releasefetcher/src/wasmJsMain/kotlin/io/github/kdroidfilter/platformtools/releasefetcher/github/VersionUtils.wasmJs.kt
+++ b/platformtools/releasefetcher/src/wasmJsMain/kotlin/io/github/kdroidfilter/platformtools/releasefetcher/github/VersionUtils.wasmJs.kt
@@ -1,0 +1,3 @@
+package io.github.kdroidfilter.platformtools.releasefetcher.github
+
+actual fun getCurrentAppVersion(): String = "0.0.0"

--- a/sample/composeApp/src/commonMain/kotlin/sample/app/ReleaseFetcherDemo.kt
+++ b/sample/composeApp/src/commonMain/kotlin/sample/app/ReleaseFetcherDemo.kt
@@ -10,7 +10,6 @@ import io.github.kdroidfilter.platformtools.releasefetcher.github.GitHubReleaseF
 import io.github.kdroidfilter.platformtools.releasefetcher.github.model.Release
 import io.github.kdroidfilter.platformtools.releasefetcher.downloader.Downloader
 import kotlinx.coroutines.launch
-import java.io.File
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -48,7 +47,7 @@ fun ReleaseFetcherDemo() {
                         val downloadLink = fetcher.getDownloadLinkForPlatform(it)
                         if (downloadLink != null) {
                             downloadStatus = "Downloading..."
-                            downloader.downloadApp(downloadLink) { percentage, file ->
+                            downloader.download(downloadLink) { percentage, file ->
                                 progress = percentage
                                 if (file != null && percentage == 100.0) {
                                     downloadStatus = "Download complete: ${file.absolutePath}"


### PR DESCRIPTION
## Summary
- add expect/actual Downloader implementation with wasmJS support
- provide platform-specific PlatformFile wrappers
- remove JVM dependencies from common GitHubReleaseFetcher
- configure wasmJs target and shared androidJvmMain source set

## Testing
- `./gradlew :platformtools:releasefetcher:compileKotlinJvm`
- `./gradlew :platformtools:releasefetcher:compileKotlinWasmJs`


------
https://chatgpt.com/codex/tasks/task_e_6847d711b69c8331ac017510599b6454