### PR TITLE
Fix release fetcher: handle null asset label

### DIFF
--- a/platformtools/releasefetcher/src/commonMain/kotlin/io/github/kdroidfilter/platformtools/releasefetcher/github/model/Asset.kt
+++ b/platformtools/releasefetcher/src/commonMain/kotlin/io/github/kdroidfilter/platformtools/releasefetcher/github/model/Asset.kt
@@ -8,7 +8,7 @@ data class Asset(
     val id: Int,
     val node_id: String,
     val name: String,
-    val label: String,
+    val label: String? = null,
     val uploader: Uploader,
     val content_type: String,
     val state: String,


### PR DESCRIPTION
Summary\n- Handle GitHub asset label being null by modeling it as nullable with a default.\n\nDetails\n- Field: assets[].label -> String? = null\n- Prevents kotlinx.serialization JsonDecodingException when GitHub returns "label": null.\n\nTesting notes\n- Ran: ./gradlew :platformtools:releasefetcher:build -x test\n- Build successful locally.\n\nModule\n- platformtools/releasefetcher