### PR TITLE
Remove external logging dependencies

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,6 @@
 androidcontextprovider = "1.0.1"
 jfa = "1.2.0"
 jna = "5.18.1"
-kermit = "2.0.6"
 kotlin = "2.2.20"
 agp = "8.9.3"
 compose = "1.9.0"
@@ -14,7 +13,6 @@ core = "1.16.0"
 activityKtx = "1.10.1"
 ktor = "3.3.1"
 navigationCompose = "2.9.0"
-slf4jSimple = "2.0.17"
 
 
 [libraries]
@@ -28,7 +26,6 @@ jna = { module = "net.java.dev.jna:jna", version.ref = "jna" }
 jna-platform = { module = "net.java.dev.jna:jna-platform", version.ref = "jna" }
 jna-jpms = { module = "net.java.dev.jna:jna-jpms", version.ref = "jna" }
 jna-platform-jpms = { module = "net.java.dev.jna:jna-platform-jpms", version.ref = "jna" }
-kermit = { module = "co.touchlab:kermit", version.ref = "kermit" }
 kotlinx-browser-wasm-js = { module = "org.jetbrains.kotlinx:kotlinx-browser-wasm-js", version.ref = "kotlinxBrowserWasmJs" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinxCoroutinesCore" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version = "1.9.0" }
@@ -40,7 +37,6 @@ ktor-client-serialization = { module = "io.ktor:ktor-client-serialization", vers
 ktor-client-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor" }
 navigation-compose = { module = "org.jetbrains.androidx.navigation:navigation-compose", version.ref = "navigationCompose" }
 semver = { module = "io.github.z4kn4fein:semver", version = "3.0.0" }
-slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4jSimple" }
 
 [plugins]
 

--- a/platformtools/appmanager/build.gradle.kts
+++ b/platformtools/appmanager/build.gradle.kts
@@ -21,7 +21,6 @@ kotlin {
         commonMain.dependencies {
             implementation(project(":platformtools:core"))
             implementation(libs.kotlinx.coroutines.core)
-            implementation(libs.kermit)
         }
 
         commonTest.dependencies {

--- a/platformtools/appmanager/src/jvmMain/kotlin/io/github/kdroidfilter/platformtools/appmanager/AppInstaller.jvm.kt
+++ b/platformtools/appmanager/src/jvmMain/kotlin/io/github/kdroidfilter/platformtools/appmanager/AppInstaller.jvm.kt
@@ -1,15 +1,12 @@
 package io.github.kdroidfilter.platformtools.appmanager
 
-import co.touchlab.kermit.Logger
-import co.touchlab.kermit.Logger.Companion.setMinSeverity
-import co.touchlab.kermit.Severity
 import io.github.kdroidfilter.platformtools.OperatingSystem
 import io.github.kdroidfilter.platformtools.appmanager.WindowsPrivilegeHelper.installOnWindows
+import io.github.kdroidfilter.platformtools.debugln
 import io.github.kdroidfilter.platformtools.getOperatingSystem
 import java.io.File
 
- val logger = Logger.withTag("AppInstaller").apply { setMinSeverity(Severity.Warn) }
-
+private const val TAG = "AppInstaller"
 
 fun getAppInstaller(): AppInstaller = DesktopInstaller()
 
@@ -33,9 +30,9 @@ class DesktopInstaller : AppInstaller {
      *                 The second parameter contains an optional error message (String?).
      */
     override suspend fun installApp(appFile: File, onResult: (Boolean, String?) -> Unit) {
-        logger.d { "Starting installation for file: ${appFile.absolutePath}" }
+        debugln(TAG) { "Starting installation for file: ${appFile.absolutePath}" }
         val osDetected = getOperatingSystem()
-        logger.d { "Detected OS: $osDetected" }
+        debugln(TAG) { "Detected OS: $osDetected" }
 
         when (osDetected) {
             OperatingSystem.WINDOWS -> installOnWindows(appFile, onResult)
@@ -43,7 +40,7 @@ class DesktopInstaller : AppInstaller {
             OperatingSystem.MACOS -> installOnMac(appFile, onResult)
             else -> {
                 val message = "Installation not supported for: ${getOperatingSystem()}"
-                logger.d { message }
+                debugln(TAG) { message }
                 onResult(false, message)
             }
         }
@@ -59,28 +56,28 @@ class DesktopInstaller : AppInstaller {
      *                 The second parameter is an optional String containing an error message or output.
      */
     private fun installOnLinux(installerFile: File, onResult: (Boolean, String?) -> Unit) {
-        logger.d { "Starting installation for .deb package." }
+        debugln(TAG) { "Starting installation for .deb package." }
 
         if (!installerFile.exists()) {
             val msg = "DEB file not found: ${installerFile.absolutePath}"
-            logger.d { msg }
+            debugln(TAG) { msg }
             onResult(false, msg)
             return
         }
 
-        logger.d { "Executing dpkg via pkexec, which will prompt for a password if needed." }
+        debugln(TAG) { "Executing dpkg via pkexec, which will prompt for a password if needed." }
 
         val command = listOf("pkexec", "dpkg", "-i", installerFile.absolutePath)
-        logger.d { "pkexec command: $command" }
+        debugln(TAG) { "pkexec command: $command" }
 
         runCommand(command) { success, output ->
-            logger.d { "pkexec + dpkg result: success=$success, output=$output" }
+            debugln(TAG) { "pkexec + dpkg result: success=$success, output=$output" }
 
             if (!success) {
-                logger.d { "dpkg via pkexec failed." }
+                debugln(TAG) { "dpkg via pkexec failed." }
                 onResult(false, output)
             } else {
-                logger.d { "DEB package installation succeeded!" }
+                debugln(TAG) { "DEB package installation succeeded!" }
                 onResult(true, output)
             }
         }
@@ -97,7 +94,7 @@ class DesktopInstaller : AppInstaller {
      *                 or an error message in case of failure.
      */
     private fun runCommand(command: List<String>, onResult: (Boolean, String?) -> Unit) {
-        logger.d { "Executing command: $command" }
+        debugln(TAG) { "Executing command: $command" }
         try {
             val process = ProcessBuilder(command)
                 .redirectErrorStream(true)
@@ -106,7 +103,7 @@ class DesktopInstaller : AppInstaller {
             val output = process.inputStream.bufferedReader().readText()
             val exitCode = process.waitFor()
 
-            logger.d { "Command completed (exitCode=$exitCode). Output: $output" }
+            debugln(TAG) { "Command completed (exitCode=$exitCode). Output: $output" }
 
             if (exitCode == 0) {
                 onResult(true, "Success. Output: $output")
@@ -115,7 +112,7 @@ class DesktopInstaller : AppInstaller {
             }
 
         } catch (e: Exception) {
-            logger.d { "Exception in runCommand(): ${e.message}" }
+            debugln(TAG) { "Exception in runCommand(): ${e.message}" }
             e.printStackTrace()
             onResult(false, "Exception during execution: ${e.message}")
         }

--- a/platformtools/clipboardmanager/build.gradle.kts
+++ b/platformtools/clipboardmanager/build.gradle.kts
@@ -24,7 +24,6 @@ kotlin {
         commonMain.dependencies {
             implementation(project(":platformtools:core"))
             implementation(libs.kotlinx.coroutines.core)
-            implementation(libs.kermit)
         }
         commonTest.dependencies {
             implementation(kotlin("test"))

--- a/platformtools/core/src/jvmMain/kotlin/io/github/kdroidfilter/platformtools/Logger.kt
+++ b/platformtools/core/src/jvmMain/kotlin/io/github/kdroidfilter/platformtools/Logger.kt
@@ -1,0 +1,65 @@
+package io.github.kdroidfilter.platformtools
+
+import java.text.SimpleDateFormat
+import java.util.Date
+
+var allowPlatformToolsLogging: Boolean = false
+var platformToolsLoggingLevel: LoggingLevel = LoggingLevel.WARN
+
+class LoggingLevel(
+    val priority: Int,
+) {
+    companion object {
+        val VERBOSE = LoggingLevel(0)
+        val DEBUG = LoggingLevel(1)
+        val INFO = LoggingLevel(2)
+        val WARN = LoggingLevel(3)
+        val ERROR = LoggingLevel(4)
+    }
+}
+
+private const val COLOR_RED = "\u001b[31m"
+private const val COLOR_AQUA = "\u001b[36m"
+private const val COLOR_LIGHT_GRAY = "\u001b[37m"
+private const val COLOR_ORANGE = "\u001b[38;2;255;165;0m"
+private const val COLOR_RESET = "\u001b[0m"
+
+private val dateFormat = SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS")
+
+private fun getCurrentTimestamp(): String = dateFormat.format(Date())
+
+fun debugln(tag: String? = null, message: () -> String) {
+    if (allowPlatformToolsLogging && platformToolsLoggingLevel.priority <= LoggingLevel.DEBUG.priority) {
+        val prefix = tag?.let { "[$it] " } ?: ""
+        println("${getCurrentTimestamp()} $prefix${message()}")
+    }
+}
+
+fun verboseln(tag: String? = null, message: () -> String) {
+    if (allowPlatformToolsLogging && platformToolsLoggingLevel.priority <= LoggingLevel.VERBOSE.priority) {
+        val prefix = tag?.let { "[$it] " } ?: ""
+        println(COLOR_LIGHT_GRAY + getCurrentTimestamp() + " " + prefix + message() + COLOR_RESET)
+    }
+}
+
+fun infoln(tag: String? = null, message: () -> String) {
+    if (allowPlatformToolsLogging && platformToolsLoggingLevel.priority <= LoggingLevel.INFO.priority) {
+        val prefix = tag?.let { "[$it] " } ?: ""
+        println(COLOR_AQUA + getCurrentTimestamp() + " " + prefix + message() + COLOR_RESET)
+    }
+}
+
+fun warnln(tag: String? = null, message: () -> String) {
+    if (allowPlatformToolsLogging && platformToolsLoggingLevel.priority <= LoggingLevel.WARN.priority) {
+        val prefix = tag?.let { "[$it] " } ?: ""
+        println(COLOR_ORANGE + getCurrentTimestamp() + " " + prefix + message() + COLOR_RESET)
+    }
+}
+
+fun errorln(tag: String? = null, throwable: Throwable? = null, message: () -> String) {
+    if (allowPlatformToolsLogging && platformToolsLoggingLevel.priority <= LoggingLevel.ERROR.priority) {
+        val prefix = tag?.let { "[$it] " } ?: ""
+        println(COLOR_RED + getCurrentTimestamp() + " " + prefix + message() + COLOR_RESET)
+        throwable?.printStackTrace()
+    }
+}

--- a/platformtools/darkmodedetector/build.gradle.kts
+++ b/platformtools/darkmodedetector/build.gradle.kts
@@ -45,7 +45,6 @@ kotlin {
                 exclude(group = "net.java.dev.jna", module = "jna-jpms")
                 exclude(group = "net.java.dev.jna", module = "jna-platform-jpms")
             }
-            implementation(libs.kermit)
         }
 
 

--- a/platformtools/darkmodedetector/src/jvmMain/kotlin/io/github/kdroidfilter/platformtools/darkmodedetector/linux/GnomeThemeDetector.kt
+++ b/platformtools/darkmodedetector/src/jvmMain/kotlin/io/github/kdroidfilter/platformtools/darkmodedetector/linux/GnomeThemeDetector.kt
@@ -4,16 +4,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import co.touchlab.kermit.Logger
-import co.touchlab.kermit.Logger.Companion.setMinSeverity
-import co.touchlab.kermit.Severity
+import io.github.kdroidfilter.platformtools.debugln
+import io.github.kdroidfilter.platformtools.errorln
 import java.io.BufferedReader
 import java.io.InputStreamReader
 import java.util.concurrent.ConcurrentHashMap
 import java.util.function.Consumer
 
-// Logger for GNOME
-private val gnomeLogger = Logger.withTag("GnomeThemeDetector").apply { setMinSeverity(Severity.Warn) }
+private const val TAG = "GnomeThemeDetector"
 
 /**
  * GNOME specific theme detector using gsettings and monitoring.
@@ -38,7 +36,7 @@ internal object GnomeThemeDetector {
                 val process = runtime.exec(cmd)
                 BufferedReader(InputStreamReader(process.inputStream)).use { reader ->
                     val line = reader.readLine()
-                    gnomeLogger.d { "Command '$cmd' output: $line" }
+                    debugln(TAG) { "Command '$cmd' output: $line" }
                     if (line != null && isDarkTheme(line)) {
                         return true
                     }
@@ -46,7 +44,7 @@ internal object GnomeThemeDetector {
             }
             false
         } catch (e: Exception) {
-            gnomeLogger.e(e) { "Couldn't detect GNOME theme" }
+            errorln(TAG, e) { "Couldn't detect GNOME theme" }
             false
         }
     }
@@ -56,12 +54,12 @@ internal object GnomeThemeDetector {
         detectorThread = object : Thread("GTK Theme Detector Thread") {
             private var lastValue: Boolean = isDark()
             override fun run() {
-                gnomeLogger.d { "Starting GTK theme monitoring thread" }
+                debugln(TAG) { "Starting GTK theme monitoring thread" }
                 val runtime = Runtime.getRuntime()
                 val process = try {
                     runtime.exec(MONITORING_CMD)
                 } catch (e: Exception) {
-                    gnomeLogger.e(e) { "Couldn't start monitoring process" }
+                    errorln(TAG, e) { "Couldn't start monitoring process" }
                     return
                 }
 
@@ -72,22 +70,22 @@ internal object GnomeThemeDetector {
                             !line.contains("color-scheme", ignoreCase = true)
                         ) continue
 
-                        gnomeLogger.d { "Monitoring output: $line" }
+                        debugln(TAG) { "Monitoring output: $line" }
                         val currentIsDark = isDarkThemeFromLine(line) ?: isDark()
                         if (currentIsDark != lastValue) {
                             lastValue = currentIsDark
-                            gnomeLogger.d { "Detected theme change => dark: $currentIsDark" }
+                            debugln(TAG) { "Detected theme change => dark: $currentIsDark" }
                             for (listener in listeners) {
                                 try { listener.accept(currentIsDark) } catch (ex: RuntimeException) {
-                                    gnomeLogger.e(ex) { "Exception while notifying listener" }
+                                    errorln(TAG, ex) { "Exception while notifying listener" }
                                 }
                             }
                         }
                     }
-                    gnomeLogger.d { "GTK theme monitoring thread ending" }
+                    debugln(TAG) { "GTK theme monitoring thread ending" }
                     if (process.isAlive) {
                         process.destroy()
-                        gnomeLogger.d { "Monitoring process destroyed" }
+                        debugln(TAG) { "Monitoring process destroyed" }
                     }
                 }
             }
@@ -142,14 +140,14 @@ internal fun isGnomeInDarkMode(): Boolean {
     val darkModeState = remember { mutableStateOf(GnomeThemeDetector.isDark()) }
 
     DisposableEffect(Unit) {
-        gnomeLogger.d { "Registering GNOME dark mode listener in Compose" }
+        debugln(TAG) { "Registering GNOME dark mode listener in Compose" }
         val listener = Consumer<Boolean> { newValue ->
-            gnomeLogger.d { "GNOME dark mode updated: $newValue" }
+            debugln(TAG) { "GNOME dark mode updated: $newValue" }
             darkModeState.value = newValue
         }
         GnomeThemeDetector.registerListener(listener)
         onDispose {
-            gnomeLogger.d { "Removing GNOME dark mode listener in Compose" }
+            debugln(TAG) { "Removing GNOME dark mode listener in Compose" }
             GnomeThemeDetector.removeListener(listener)
         }
     }

--- a/platformtools/darkmodedetector/src/jvmMain/kotlin/io/github/kdroidfilter/platformtools/darkmodedetector/mac/MacOSThemeDetector.kt
+++ b/platformtools/darkmodedetector/src/jvmMain/kotlin/io/github/kdroidfilter/platformtools/darkmodedetector/mac/MacOSThemeDetector.kt
@@ -7,18 +7,16 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import co.touchlab.kermit.Logger
-import co.touchlab.kermit.Logger.Companion.setMinSeverity
-import co.touchlab.kermit.Severity
 import de.jangassen.jfa.foundation.Foundation
 import de.jangassen.jfa.foundation.ID
+import io.github.kdroidfilter.platformtools.debugln
+import io.github.kdroidfilter.platformtools.errorln
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executors
 import java.util.function.Consumer
 import java.util.regex.Pattern
 
-// Initialize logger using kotlin-logging
-private val macLogger = Logger.withTag("MacOSThemeDetector").apply { setMinSeverity(Severity.Warn) }
+private const val TAG = "MacOSThemeDetector"
 
 /**
  * MacOSThemeDetector registers an observer with NSDistributedNotificationCenter
@@ -48,7 +46,7 @@ internal object MacOSThemeDetector {
         fun callback() {
             callbackExecutor.execute {
                 val isDark = isDark()
-                macLogger.d { "Theme change detected. Dark mode: $isDark" }
+                debugln(TAG) { "Theme change detected. Dark mode: $isDark" }
                 notifyListeners(isDark)
             }
         }
@@ -66,7 +64,7 @@ internal object MacOSThemeDetector {
      * and registers the observer with NSDistributedNotificationCenter.
      */
     private fun initObserver() {
-        macLogger.d { "Initializing macOS theme observer" }
+        debugln(TAG) { "Initializing macOS theme observer" }
         val pool = Foundation.NSAutoreleasePool()
         try {
             val delegateClass: ID = Foundation.allocateObjcClassPair(
@@ -77,7 +75,7 @@ internal object MacOSThemeDetector {
                 val selector = Foundation.createSelector("handleAppleThemeChanged:")
                 val added = Foundation.addMethod(delegateClass, selector, themeChangedCallback, "v@")
                 if (!added) {
-                    macLogger.e { "Failed to add observer method to NSColorChangesObserver" }
+                    errorln(TAG) { "Failed to add observer method to NSColorChangesObserver" }
                 }
                 Foundation.registerObjcClassPair(delegateClass)
             }
@@ -90,7 +88,7 @@ internal object MacOSThemeDetector {
                 Foundation.nsString("AppleInterfaceThemeChangedNotification"),
                 ID.NIL
             )
-            macLogger.d { "Observer successfully registered" }
+            debugln(TAG) { "Observer successfully registered" }
         } finally {
             pool.drain()
         }
@@ -109,7 +107,7 @@ internal object MacOSThemeDetector {
             val styleString = Foundation.toStringViaUTF8(result)
             darkPattern.matcher(styleString ?: "").matches()
         } catch (e: Exception) {
-            macLogger.e(e) { "Error reading system theme" }
+            errorln(TAG, e) { "Error reading system theme" }
             false
         } finally {
             pool.drain()
@@ -138,14 +136,14 @@ internal object MacOSThemeDetector {
 internal fun isMacOsInDarkMode(): Boolean {
     val darkModeState = remember { mutableStateOf(MacOSThemeDetector.isDark()) }
     DisposableEffect(Unit) {
-        macLogger.d { "Registering macOS dark mode listener in Compose" }
+        debugln(TAG) { "Registering macOS dark mode listener in Compose" }
         val listener = Consumer<Boolean> { newValue ->
-            macLogger.d { "Compose macOS dark mode updated: $newValue" }
+            debugln(TAG) { "Compose macOS dark mode updated: $newValue" }
             darkModeState.value = newValue
         }
         MacOSThemeDetector.registerListener(listener)
         onDispose {
-            macLogger.d { "Removing macOS dark mode listener in Compose" }
+            debugln(TAG) { "Removing macOS dark mode listener in Compose" }
             MacOSThemeDetector.removeListener(listener)
         }
     }

--- a/platformtools/darkmodedetector/src/jvmMain/kotlin/io/github/kdroidfilter/platformtools/darkmodedetector/windows/WindowsThemeDetector.kt
+++ b/platformtools/darkmodedetector/src/jvmMain/kotlin/io/github/kdroidfilter/platformtools/darkmodedetector/windows/WindowsThemeDetector.kt
@@ -7,9 +7,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import co.touchlab.kermit.Logger
-import co.touchlab.kermit.Logger.Companion.setMinSeverity
-import co.touchlab.kermit.Severity
 import com.sun.jna.Native
 import com.sun.jna.platform.win32.*
 import com.sun.jna.platform.win32.WinNT.KEY_READ
@@ -17,13 +14,14 @@ import com.sun.jna.platform.win32.WinReg.HKEY
 import com.sun.jna.ptr.IntByReference
 import io.github.kdroidfilter.platformtools.OperatingSystem
 import io.github.kdroidfilter.platformtools.darkmodedetector.isSystemInDarkMode
+import io.github.kdroidfilter.platformtools.debugln
+import io.github.kdroidfilter.platformtools.errorln
 import io.github.kdroidfilter.platformtools.getOperatingSystem
 import java.awt.Window
 import java.util.concurrent.ConcurrentHashMap
 import java.util.function.Consumer
 
-// Initialize logger using kotlin-logging
-internal val windowsLogger = Logger.withTag("WindowsThemeDetector").apply { setMinSeverity(Severity.Warn) }
+private const val TAG = "WindowsThemeDetector"
 
 /**
  * WindowsThemeDetector uses JNA to read the Windows registry value:
@@ -97,7 +95,7 @@ internal object WindowsThemeDetector {
             private var lastValue = isDark()
 
             override fun run() {
-                windowsLogger.d { "Windows theme monitor thread started" }
+                debugln(TAG) { "Windows theme monitor thread started" }
 
                 // Open the registry key for reading
                 val hKeyRef = WinReg.HKEYByReference()
@@ -109,7 +107,7 @@ internal object WindowsThemeDetector {
                     hKeyRef
                 )
                 if (openErr != WinError.ERROR_SUCCESS) {
-                    windowsLogger.e { "RegOpenKeyEx failed with code $openErr" }
+                    errorln(TAG) { "RegOpenKeyEx failed with code $openErr" }
                     return
                 }
                 val hKey: HKEY = hKeyRef.value
@@ -126,28 +124,28 @@ internal object WindowsThemeDetector {
                             false
                         )
                         if (notifyErr != WinError.ERROR_SUCCESS) {
-                            windowsLogger.e { "RegNotifyChangeKeyValue failed with code $notifyErr" }
+                            errorln(TAG) { "RegNotifyChangeKeyValue failed with code $notifyErr" }
                             return
                         }
 
                         val currentValue = isDark()
                         if (currentValue != lastValue) {
                             lastValue = currentValue
-                            windowsLogger.d { "Windows theme changed => dark: $currentValue" }
+                            debugln(TAG) { "Windows theme changed => dark: $currentValue" }
                             // Notify all listeners
                             val snapshot = listeners.toList()
                             for (l in snapshot) {
                                 try {
                                     l.accept(currentValue)
                                 } catch (e: RuntimeException) {
-                                    windowsLogger.e(e) { "Error while notifying listener" }
+                                    errorln(TAG, e) { "Error while notifying listener" }
                                 }
                             }
                         }
                     }
                 } finally {
                     // Close the registry key
-                    windowsLogger.d { "Detector thread closing registry key" }
+                    debugln(TAG) { "Detector thread closing registry key" }
                     Advapi32Util.registryCloseKey(hKey)
                 }
             }
@@ -172,16 +170,16 @@ internal fun isWindowsInDarkMode(): Boolean {
     val darkModeState = remember { mutableStateOf(WindowsThemeDetector.isDark()) }
 
     DisposableEffect(Unit) {
-        windowsLogger.d { "Registering Windows dark mode listener in Compose" }
+        debugln(TAG) { "Registering Windows dark mode listener in Compose" }
         val listener = Consumer<Boolean> { newValue ->
-            windowsLogger.d { "Windows dark mode updated: $newValue" }
+            debugln(TAG) { "Windows dark mode updated: $newValue" }
             darkModeState.value = newValue
         }
 
         WindowsThemeDetector.registerListener(listener)
 
         onDispose {
-            windowsLogger.d { "Removing Windows dark mode listener in Compose" }
+            debugln(TAG) { "Removing Windows dark mode listener in Compose" }
             WindowsThemeDetector.removeListener(listener)
         }
     }
@@ -220,6 +218,6 @@ fun Window.setWindowsAdaptiveTitleBar(dark: Boolean = isSystemInDarkMode()) {
             )
         }
     } catch (e: Exception) {
-        windowsLogger.d { "Failed to set dark mode: ${e.message}" }
+        debugln(TAG) { "Failed to set dark mode: ${e.message}" }
     }
 }

--- a/platformtools/releasefetcher/build.gradle.kts
+++ b/platformtools/releasefetcher/build.gradle.kts
@@ -30,7 +30,6 @@ kotlin {
             compileOnly(libs.ktor.client.logging)
             compileOnly(libs.ktor.client.cio)
             api(libs.semver)
-            implementation(libs.kermit)
 
         }
 
@@ -44,9 +43,6 @@ kotlin {
 
         jvmMain {
             dependsOn(androidJvmMain)
-            dependencies {
-                implementation(libs.slf4j.simple)
-            }
         }
 
         androidMain {

--- a/platformtools/rtlwindows/build.gradle.kts
+++ b/platformtools/rtlwindows/build.gradle.kts
@@ -21,7 +21,6 @@ kotlin {
         commonMain.dependencies {
             implementation(project(":platformtools:core"))
             implementation(libs.kotlinx.coroutines.core)
-            implementation(libs.kermit)
             implementation(libs.jna.jpms)
             implementation(libs.jna.platform.jpms)
         }


### PR DESCRIPTION
## Summary
- Remove Kermit and SLF4J external logging dependencies from all modules
- Add simple internal `Logger.kt` in the core module with colored terminal output
- Update all JVM source files to use the new internal logger

## Changes
- **New file**: `platformtools/core/src/jvmMain/kotlin/io/github/kdroidfilter/platformtools/Logger.kt`
- **Removed dependencies**: `co.touchlab:kermit`, `org.slf4j:slf4j-simple`
- **Updated modules**: appmanager, darkmodedetector, clipboardmanager, releasefetcher, rtlwindows

## Usage
Logging is disabled by default. To enable:
```kotlin
allowPlatformToolsLogging = true
platformToolsLoggingLevel = LoggingLevel.DEBUG // or VERBOSE, INFO, WARN, ERROR
```